### PR TITLE
Add UDFs to glossary

### DIFF
--- a/docs/docs/arch.md
+++ b/docs/docs/arch.md
@@ -2,12 +2,12 @@
 
 The OpenEO core API defines a language how clients communicate to back-ends in order to analyze large Earth observation datasets. The API will be implemented by drivers for specific back-ends. Some first architecture considerations are listed below.
 
-1. The OpenEO core API is a contract betewen clients and backends that describes the communication only
+1. The OpenEO core API is a contract between clients and back-ends that describes the communication only
 2. Each back-end runs its own API instance including the specific back-end driver. There is no core API instance that runs more than one driver.
-3. Clients in R, Python, and JavaScript connect directly to the backends and communicate with the backends over HTTP(s) acoording to the OpenEO core API specification.
+3. Clients in R, Python, and JavaScript connect directly to the back-ends and communicate with the back-ends over HTTP(s) according to the OpenEO core API specification.
 4. API instances can run on back-end servers or additional intermediate layers, which then communicate to back-ends in a back-end specific way.
 5. Back-ends may add functionality and extend the core API wherever there is need.
-6. There will be a central backend registry service, to allow users to search for backends with specific functionality and or data. 
+6. There will be a central back-end registry service, to allow users to search for back-ends with specific functionality and or data. 
 7. The OpenEO core API will define _profiles_ in order group specific functionality.
 
 ![Architecture](arch.png)
@@ -20,7 +20,7 @@ To simplify and structure the development, the API is divided into a few microse
 | Microservice               | Description                                                  |
 | -------------------------- | ------------------------------------------------------------ |
 | Capabilities               | This microservice reports on the capabilities of the back-end, i.e. which API endpoints are implemented, which authentication methods are supported, and whether and how UDFs can be executed at the back-end. |
-| EO Data Discovery          | Describes which datasets and image collections are available at the backend. |
+| EO Data Discovery          | Describes which datasets and image collections are available at the back-end. |
 | Process Discovery          | Provides services to find out which processes a back-end provides, i.e., what users can do with the available data. |
 | UDF Runtime Discovery      | Allows discovering the programming languages and their runtime environments to execute user-defined functions. |
 | Job Management             | Organizes and manages jobs that run processes on back-ends.  |

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -72,3 +72,7 @@ When the target grid or time series has a lower resolution (larger grid cells) o
 ## API
 
 The API developed by the openEO project uses [HTTP REST](https://en.wikipedia.org/wiki/Representational_state_transfer) for communication between client and back-end server.
+
+## User-defined functions (UDFs)
+
+The abbreviation **UDF** stands for **user-defined function**. With this concept, users are able to upload custom code and have it executed e.g. for every pixel of a scene, allowing custom calculations on server-side data.

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -10,16 +10,20 @@ The acronym _openEO_ contracts two concepts:
 Further terms:
 
 - **API**: application programming interface ([wikipedia](https://en.wikipedia.org/wiki/Application_programming_interface)); a communication protocol between client and back-end
-- **client**: software environment (software) that end-users directly interact with, e.g. R (rstudio), python (jupyter notebook), and javascript (web browser); R and python are two major data science platforms; javascript is a major language for web development
+- **client**: software environment (software) that end-users directly interact with, e.g. R (rstudio), Python (jupyter notebook), and JavaScript (web browser); R and Python are two major data science platforms; JavaScript is a major language for web development
 - **(cloud) back-end**: server; computer infrastructure (one or more physical computers or virtual machines) used for storing EO data and processing it
 - **big Earth observation cloud back-end** server infrastructure where industry and researchers analyse large amounts of EO data
-- **simple** many end-users now use python or R to analyse data and javascript to develop web applications; analysing large amounts of EO imagery should be equally simple, and seamlessly integrate with existing workflows
+- **simple** many end-users now use Python or R to analyse data and JavaScript to develop web applications; analysing large amounts of EO imagery should be equally simple, and seamlessly integrate with existing workflows
 - **unified** current EO cloud back-ends all have [a different API](http://r-spatial.org/2016/11/29/openeo.html), making EO data analysis hard to validate,difficult to reproduce, and back-ends difficult to compare in terms of capability and costs, or to combine in a joint analysis across back-ends. A unified API can resolve many of these problems.
 
 
 ## Datasets
 
-CEOS ([CEOS OpenSearch Best Practice Document v1.2](http://ceos.org/ourwork/workinggroups/wgiss/access/opensearch/)) defines **Granules** and **Collections** as follows: "A ***granule*** is the finest granularity of data that can be independently managed. A granule usually matches the individual file of EO satellite data.", and "A ***collection*** is an aggregation of granules sharing the same product specification. A collection typically corresponds to the series of products derived from data acquired by a sensor on board a satellite and having the same mode of operation."
+CEOS ([CEOS OpenSearch Best Practice Document v1.2](http://ceos.org/ourwork/workinggroups/wgiss/access/opensearch/)) defines **Granules** and **Collections** as follows:
+
+> "A ***granule*** is the finest granularity of data that can be independently managed. A granule usually matches the individual file of EO satellite data."
+
+> "A ***collection*** is an aggregation of granules sharing the same product specification. A collection typically corresponds to the series of products derived from data acquired by a sensor on board a satellite and having the same mode of operation."
 
 The same document lists the synonyms used (by organisations) for:
 
@@ -43,7 +47,7 @@ In this context OpenEO will:
 1. consider, or allow to consider, band as a dimension
 2. consider imagery (image collections) to consist of one _or more_ collections, as argument to functions; allow filtering on a particular collection, or joining them into a single collection
 3. allow filtering on attributes, e.g. on cloud-free pixels, or pixels inside a `MULTIPOLYGON` describing the floodplains of the Danube. This filters on attributes rather than dimensions.
-4. Provide generic aggregate operations that aggregate over one or more dimenions. Clients may provide dimension-specific aggregation functions for particular cases (such as `min_time`) 
+4. Provide generic aggregate operations that aggregate over one or more dimensions. Clients may provide dimension-specific aggregation functions for particular cases (such as `min_time`) 
 
 A **process graph** includes specific process calls, i.e. references to one or more processes including specific values for input arguments similar to a function call in programming. However, process graphs can chain multiple processes. In particular, arguments of processes in general can be again (recursive) process graphs, input datasets, or simple scalar or array values.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -2,7 +2,7 @@
 
 _Work in progress, please contribute by adding [issues](https://github.com/Open-EO/openeo-api-poc/issues)._
 
-openEO develops an open API that connects clients like R, python and javascript to big Earth observation cloud back-ends in a simple and unified way. 
+openEO develops an open API that connects clients like R, Python and JavaScript to big Earth observation cloud back-ends in a simple and unified way.
 
 The following pages introduce the core concepts of the project. Make sure to introduce yourself to the major technical terms used in the openEO project by reading the [glossary](glossary.md).
 

--- a/docs/docs/poc.md
+++ b/docs/docs/poc.md
@@ -682,7 +682,7 @@ Body:
 
 **Example Request**
 ```
-GET hhttp://cdn.cloudprovider.com/openeo/services/9dab4b6f6523/tms/2017-01-01/12/2232/2668/?bands=1 HTTP/1.1
+GET http://cdn.cloudprovider.com/openeo/services/9dab4b6f6523/tms/2017-01-01/12/2232/2668/?bands=1 HTTP/1.1
 ```
 
 **Response**

--- a/docs/docs/processgraphs.md
+++ b/docs/docs/processgraphs.md
@@ -23,7 +23,7 @@ A process must always contain two key-value-pairs named `process_id` and `args` 
 * Backend-defined processes, which are listed at `GET /processes`, e.g. `filter_bands`.
 * User-defined process graphs, which are listed at `GET /users/{user_id}/process_graphs`. 
   They are prefixed with `/user/`, e.g. `/user/my_process_graph`.
-* User-defined functions (UDF), which is one of the predefined [UDF types](udfs.md) and can be explored at `GET /udf_runtimes/{lang}/{udf_type}`. UDFs are prefixed with `/udf` and contain also the runtime and the process name separated by `/`, e.g. `/udf/Python/apply_pixel`.
+* User-defined functions (UDF), which is one of the predefined [UDF types](udfs.md) and can be explored at `GET /udf_runtimes/{lang}/{udf_type}`. UDFs are prefixed with `/udf` and additionally contain the runtime and the process name separated by `/`, e.g. `/udf/Python/apply_pixel`.
 
 **Example 1:**
 
@@ -74,7 +74,7 @@ An argument set for a process is defined as follows:
 }
 ```
 
-Whereas a key (`<Key>`) can be any valid JSON key and a value is defined as:
+Where a key (`<Key>`) can be any valid JSON key and a value is defined as:
 ```
 <Value> := <string|number|array|boolean|null|Process|ImageCollection>
 ```
@@ -96,6 +96,7 @@ Whereas a key (`<Key>`) can be any valid JSON key and a value is defined as:
   }
 }
 ```
+
 **Example 3:**
 
 If a process needs multiple processes or image collections as input, it is allowed to use arrays of the respective types.
@@ -158,7 +159,7 @@ There are some processes that we define to be core processes that should be impl
 * process_graph
 * _to be continued..._
 
-_Note:_ Currently there are few defined processes only. Those are currently only meant as an example how future documentation of processes might look like and to supplement the schematic definition above.
+_Note:_ Currently there are only few defined processes. Those are currently only meant as an example how future documentation of processes might look like and to supplement the schematic definition above.
 
 _Limitation:_ Process names (process ids) must never contain a forward slash `/`.
 
@@ -168,7 +169,7 @@ Allows to extract one or multiple bands of multi-band raster image collection. B
 
 #### Arguments
 
-* `imagery`*: Image collection to filter
+* `imagery` *(required)*: Image collection to filter
 
 And one of:
 
@@ -177,6 +178,7 @@ And one of:
 * `wavelengths`: number or two-element array of numbers containing a wavelength or a minimum and maximum wavelength respectively.
 
 #### Examples
+
 ```
 {
   "process_id": "filter_bands",
@@ -188,6 +190,7 @@ And one of:
   }
 }
 ```
+
 ```
 {
   "process_id": "filter_bands",
@@ -199,22 +202,22 @@ And one of:
   }
 }
 ```
+
 ### filter_daterange
 
 Allows to filter an image collection by temporal extent.
 
 #### Arguments
 
-- `imagery`*: Image collection to filter
+* `imagery` *(required)*: Image collection to filter
 
 And at least one of:
 
-- `from`: Includes all data newer than the specified ISO 8601 date or date-time with simultaneous consideration of `to`.
-
-
-- `to`: Includes all data older than the specified ISO 8601 date or date-time with simultaneous consideration of `from`.
+* `from`: Includes all data newer than the specified ISO 8601 date or date-time with simultaneous consideration of `to`.
+* `to`: Includes all data older than the specified ISO 8601 date or date-time with simultaneous consideration of `from`.
 
 #### Examples
+
 ```
 {
   "process_id":"filter_daterange",
@@ -234,8 +237,8 @@ Another process graph can be referenced with the process `process_graph`. This c
 
 #### Arguments
 
-* `imagery`*: Image collection to apply the process graph to
-* `uri`*: An URI to a process graph.
+* `imagery` *(required)*: Image collection to apply the process graph to
+* `uri` *(required)*: An URI to a process graph.
 
 #### Examples
 
@@ -250,4 +253,5 @@ Another process graph can be referenced with the process `process_graph`. This c
   }
 }
 ```
+
 ### _to be continued..._

--- a/docs/docs/udfs.md
+++ b/docs/docs/udfs.md
@@ -1,4 +1,4 @@
-# UDFs
+# User-defined functions
 
 User-defined functions (UDFs) can be exposed to the data in different ways. This includes which parts of the data are passed to the function, how the function execution is parallelized, and how the expected output is structured. The OpenEO core API defines the following UDF types:
 
@@ -17,7 +17,7 @@ User-defined functions (UDFs) can be exposed to the data in different ways. This
 - [chunkreduce_spacetime](#chunkreduce_spacetime)
 
 
-This document describes some details of the abovementioned UDF types. Back-ends allowing the execution of UDF's will report, which types they support. For example applying UDFs on individual scenes is not possible on higher level data cube back-ends. In the descriptions below, the question in which format data is streamed to and from the functions is not yet covered. Furthermore, the described categories only include unary operations that take one image (collection) as input.
+This document describes some details of the abovementioned UDF types. Back-ends allowing the execution of UDFs will report which types they support. For example, applying UDFs on individual scenes is not possible on higher level data cube back-ends. In the descriptions below, the question in which format data is streamed to and from the functions is not yet covered. Furthermore, the described categories only include unary operations that take one image (collection) as input.
 
 You can use UDFs in a process graph as shown in the [examples for proof-of-concept use case 2](poc.md#use-case-2). Generally UDFs in the process graphs are prefixed with `/udf` and contain also the runtime and the process name separated by `/`, e.g. `/udf/Python/apply_pixel`. Runtimes can be discovered at `GET /udf_runtimes`. Process description of UDF schemas and can be retrieved at `GET /udf_runtimes/{lang}/{udf_type}`. 
 


### PR DESCRIPTION
Mentioning UDFs in the glossary is the only real change.
> If terms as common as "API" are included in the glossary, the not so common abbreviation "UDF" should be explained there too. In general the concept of UDFs is worthy of a brief description there IMO - I tried to come up with something, please replace or amend as you see fit.

All other changes are just fixed typos etc.